### PR TITLE
Fixing build ... merge error

### DIFF
--- a/brooklyn-server/launcher/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncher.java
+++ b/brooklyn-server/launcher/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncher.java
@@ -53,7 +53,7 @@ public class BrooklynJavascriptGuiLauncher {
         // For Eclipse, use the default option of ${workspace_loc:brooklyn-launcher}.
         // If the working directory is not set correctly, Brooklyn will be unable to find the jsgui .war
         // file and the 'gui not available' message will be shown.
-        startJavascriptAndRestWithDefaultCatalog();
+        startJavascriptAndRest();
         
         log.info("Press Ctrl-C to quit.");
     }


### PR DESCRIPTION
Method `startJavascriptAndRestWithDefaultCatalog()` has been renamed to `startJavascriptAndRest()`
